### PR TITLE
PF-109: Fix homepage label override for mobile layout

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -6,7 +6,7 @@
   "organization": "Supernova",
   "source_dir": "src",
   "assets_dir": "assets",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "usesBrands": false,
   "config": {
     "sources": "sources.json",

--- a/src/page_body/structure/page_body_structure_header.pr
+++ b/src/page_body/structure/page_body_structure_header.pr
@@ -57,7 +57,7 @@
                 </ul>
 
                 <div class="utility-nav">
-                    
+
                     {[ if shouldShowTabbar ]}
                     <div id="mobile-menu-container" class="dropdown">
                         <button class="btn btn-secondary btn-outlined" type="button" id="mobile-menu-selector" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">   
@@ -67,7 +67,8 @@
                                     {* {[ if item.type.equals("Group") ]} *}
                                         {[ let isActive = pageOrGroupActiveInContext(page, item) /]}
                                         {[ if isActive ]}
-                                            {{ item.title }}
+                                            {[ let itemTitle = resolveMenuLabel(item, rootGroup, configuration.navigationOverrideHomepageLabel) /]}
+                                            {{ itemTitle }}
                                         {[/]}
                                     {* {[/]} *}
                                 {[/]}
@@ -77,7 +78,8 @@
                                 {* Only show if group or page is not hidden *}
                                 {[ if isExportable(item) ]}
                                     {[ let activeClass = (pageOrGroupActiveInContext(page, item) === true ? "checked" : "") /]}
-                                    <a class="dropdown-item {{ activeClass }}" href="{{ pageUrl(item, ds.documentationDomain()) }}">{{ item.title }}</a>
+                                    {[ let itemTitle = resolveMenuLabel(item, rootGroup, configuration.navigationOverrideHomepageLabel) /]}
+                                    <a class="dropdown-item {{ activeClass }}" href="{{ pageUrl(item, ds.documentationDomain()) }}">{{ itemTitle }}</a>
                                 {[/]}
                             {[/]}
                         </div>


### PR DESCRIPTION
<img width="884" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/5a79f1e0-7ba5-426a-92f1-c497117fff43">

Fixes showing homepage override for mobile layout as well

<img width="647" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/1bde0958-21c3-4f57-91be-1ad33ce5aa8d">

<img width="971" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/01f8be17-e1a9-4f84-bbb2-2d815dae0c3e">
