### PR TITLE
PF-124: Do not perform fetch requests to not http storybook endpoints

### DIFF
--- a/assets/js/functionality.js
+++ b/assets/js/functionality.js
@@ -299,6 +299,11 @@ $(document).ready(function() {
     // otherwise show formatted error message
     document.querySelectorAll('iframe.storybook').forEach(iframe => {
         let src = iframe.getAttribute('src');
+
+        if (!src.startsWith('https://')) {
+            return;
+        }
+
         fetch(src, {
                 method: 'GET',
                 cache: 'no-cache',

--- a/exporter.json
+++ b/exporter.json
@@ -6,7 +6,7 @@
   "organization": "Supernova",
   "source_dir": "src",
   "assets_dir": "assets",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "usesBrands": false,
   "config": {
     "sources": "sources.json",


### PR DESCRIPTION
When Storybook content is served via unsecure HTTP protocol we can't perform `fetch` request to validate iframe content accessibility because documentation is served via HTTPS and browsers do not allow mixed content.
So, accessibility validation will be skipped for not HTTPS iframe.