### PR TITLE
PF-134: Fix invalid component url when page was not yet deployed by previous Publish

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -6,7 +6,7 @@
   "organization": "Supernova",
   "source_dir": "src",
   "assets_dir": "assets",
-  "version": "4.7.3",
+  "version": "4.7.4",
   "usesBrands": false,
   "config": {
     "sources": "sources.json",

--- a/src/page_body/structure/blocks/custom-properties/custom_properties_value.pr
+++ b/src/page_body/structure/blocks/custom-properties/custom_properties_value.pr
@@ -31,8 +31,11 @@
         {[ if customProperty.linkElementType.equals("DocumentationPage") ]}
             {[ let page = ds.documentationPageById(customPropertyValue) /]}
 
-            {[ if page.deployedUrl ]}
-                <a class="{{ ["property-link", sizeClass].join(" ") }}" href="{{ page.deployedUrl }}">{[ inject "icon_documentation_page" context configuration /]} Open page</a>
+            {[ if page.relativeUrl ]}
+                {[ let version = ds.currentDesignSystemVersion() /]}
+                {[ let versionPath = (version.isSharedDraft ? "latest" : version.version ) /]}
+
+                <a class="{{ ["property-link", sizeClass].join(" ") }}" href="/{{versionPath}}/{{ page.relativeUrl }}">{[ inject "icon_documentation_page" context configuration /]} Open page</a>
             {[ else ]}
                 -
             {[/]}

--- a/src/page_body/structure/blocks/page_block_component_checklist_all.pr
+++ b/src/page_body/structure/blocks/page_block_component_checklist_all.pr
@@ -54,7 +54,10 @@
                         <td class="name">
                             {[ if component.propertyValues["documentationLink"] ]}
                                 {[ let page = ds.documentationPageById(component.propertyValues["documentationLink"]) /]}
-                                <a href="{{ page.deployedUrl }}">{{ component.name }}</a>
+                                {[ let version = ds.currentDesignSystemVersion() /]}
+                                {[ let versionPath = (version.isSharedDraft ? "latest" : version.version ) /]}
+
+                                <a href="/{{versionPath}}/{{ page.relativeUrl }}">{{ component.name }}</a>
                             {[ else ]}
                                 {{ component.name }}
                             {[/]}


### PR DESCRIPTION
This fix handles several issues:
1. When Preview documentation is built it used links to the main documentation.
2. The link was applied only if linked page was already deployed by one of the previous Publish but in cases when it a new page it was required to Publish documentation twice to make link work

So, instead of using published documentation url this fix proposes to use relative path of the processing page and it should correctly work both with Preview and Publish environments