### PR TITLE
PF-134: Fix generating links when page was removed

### DIFF
--- a/src/page_body/structure/blocks/custom-properties/custom_properties_value.pr
+++ b/src/page_body/structure/blocks/custom-properties/custom_properties_value.pr
@@ -31,7 +31,7 @@
         {[ if customProperty.linkElementType.equals("DocumentationPage") ]}
             {[ let page = ds.documentationPageById(customPropertyValue) /]}
 
-            {[ if page.relativeUrl ]}
+            {[ if ( page && page.relativeUrl) ]}
                 {[ let version = ds.currentDesignSystemVersion() /]}
                 {[ let versionPath = (version.isSharedDraft ? "latest" : version.version ) /]}
 

--- a/src/page_body/structure/blocks/page_block_component_checklist_all.pr
+++ b/src/page_body/structure/blocks/page_block_component_checklist_all.pr
@@ -52,7 +52,7 @@
                     {[ let propertyValues = component.propertyValues /]}
                     <tr>
                         <td class="name">
-                            {[ if component.propertyValues["documentationLink"] ]}
+                            {[ if (component.propertyValues["documentationLink"] && ds.documentationPageById(component.propertyValues["documentationLink"])) ]}
                                 {[ let page = ds.documentationPageById(component.propertyValues["documentationLink"]) /]}
                                 {[ let version = ds.currentDesignSystemVersion() /]}
                                 {[ let versionPath = (version.isSharedDraft ? "latest" : version.version ) /]}


### PR DESCRIPTION
Fix for cases when referenced page from Components or Tokens was removed. Then this link will not be present on the page that has Token blocks or Component Overview block.