### PR TITLE
PF-136: Not sanitized cookie text lead to incorrect html parsing and broken search forms

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -6,7 +6,7 @@
   "organization": "Supernova",
   "source_dir": "src",
   "assets_dir": "assets",
-  "version": "4.7.6",
+  "version": "4.7.7",
   "usesBrands": false,
   "config": {
     "sources": "sources.json",

--- a/src/page_body/support/page_body_scripts.pr
+++ b/src/page_body/support/page_body_scripts.pr
@@ -51,7 +51,7 @@ $(document).ready(function() {
     const cookieConsent = new CookieConsent({
         content: {
             "title": "{{ escapeHtml(configuration.cookiesBannerTitle) }}",
-            "body": "{{ addSlashes(configuration.cookiesBannerDescription) }}",
+            "body": "{{ withHTMLNewlines(escapeHtml(addSlashes(configuration.cookiesBannerDescription))) }}",
         },
         postSelectionCallback: () => { 
             {[ if (GoogleAnalyticsKey && GoogleAnalyticsKey.count() > 0) ]} initGoogleAnalytics(); {[/]}


### PR DESCRIPTION
When cookie consent text has line breaks that leads to broken html initilization and not working search further.

<img width="1380" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/fc9f09a2-47fd-4ee0-b071-ca0fc610022d">

after fix:
<img width="1374" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/59c135ce-9d23-40ec-bce6-af9c4baafc6b">

