### PR TITLE
PF-136: Do not crush when ad blocker blocks cookie consent loading

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -6,7 +6,7 @@
   "organization": "Supernova",
   "source_dir": "src",
   "assets_dir": "assets",
-  "version": "4.7.10",
+  "version": "4.7.11",
   "usesBrands": false,
   "config": {
     "sources": "sources.json",

--- a/src/page_body/support/page_body_scripts.pr
+++ b/src/page_body/support/page_body_scripts.pr
@@ -47,22 +47,27 @@ $(document).ready(function() {
     const sandboxConfigUrl = "{{ domain }}/../sandbox.json"
     loadSandboxes(sandboxConfigUrl)
 
-    {[ if configuration.enableCookiesBanner ]}
-    const cookieConsent = new CookieConsent({
-        content: {
-            "title": "{{ escapeHtml(configuration.cookiesBannerTitle) }}",
-            "body": "{{ withHTMLNewlines(addSlashes(configuration.cookiesBannerDescription)) }}",
-        },
-        postSelectionCallback: () => { 
-            {[ if (GoogleAnalyticsKey && GoogleAnalyticsKey.count() > 0) ]} initGoogleAnalytics(); {[/]}
-            {[ if (HotjarSiteId && HotjarSiteId.count() > 0) ]} initHotjar(); {[/]}
-            },
-    });
-    {[/]}
 
     $("input[data-toggle='list-search']").on("keyup", function() {
         searchInList($(this),$(this).attr("data-list-id"));
     });
+
+    {[ if configuration.enableCookiesBanner ]}
+        if (window.CookieConsent !== undefined && typeof window.CookieConsent === "function") {
+            const cookieConsent = new CookieConsent({
+                content: {
+                    "title": "{{ escapeHtml(configuration.cookiesBannerTitle) }}",
+                    "body": "{{ withHTMLNewlines(addSlashes(configuration.cookiesBannerDescription)) }}",
+                },
+                postSelectionCallback: () => {
+                    {[ if (GoogleAnalyticsKey && GoogleAnalyticsKey.count() > 0) ]} initGoogleAnalytics(); {[/]}
+                    {[ if (HotjarSiteId && HotjarSiteId.count() > 0) ]} initHotjar(); {[/]}
+                    },
+            });
+        } else {
+            console.log('Showing Cookie Consent was blocked by browser')
+        }
+    {[/]}
 })
 </script>
 
@@ -107,11 +112,11 @@ $(document).ready(function() {
     }
 
     {[ if configuration.enableCookiesBanner ]}
-    if (getCookieValue("cookie-consent-tracking-allowed") === "true") {
-        initHotjar()
-    }
+        if (getCookieValue("cookie-consent-tracking-allowed") === "true") {
+            initHotjar()
+        }
     {[ else ]}
-    initHotjar()
+        initHotjar()
     {[/]}
 
     


### PR DESCRIPTION
Because Brave completely blocks cookies from loading (not just for storing) and that's why this `CookieConsent` object is not defined and further page initialization is blocked (including part for search blocks).

<img width="1149" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/89ef2f19-6606-4796-ab80-8d27c0325588">

