### PR TITLE
ENG-1151: Fix navigation highlight

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -6,7 +6,7 @@
   "organization": "Supernova",
   "source_dir": "src",
   "assets_dir": "assets",
-  "version": "4.7.14",
+  "version": "4.7.15",
   "usesBrands": false,
   "config": {
     "sources": "sources.json",


### PR DESCRIPTION
This PR contains 2 fixes:
1. When page is opened with paragraph section in URL hash it is not scrolled to this section.
By default, browser automatically should scroll to anchor in hash. I could not reproduce client's case but explicit scroll I added should solve this issue.

2. When H3 content items are hidden there are Console errors and nothing gets selected.

<img width="1164" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/3d5de741-edf5-4a80-9feb-c6c2f69a8502">

After fix:
<img width="1220" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/a6c1dc24-5462-4ea3-8bd9-50af1fc02b5c">
