### PR TITLE
PF-155: Escape page title and description in SEO block

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -6,7 +6,7 @@
   "organization": "Supernova",
   "source_dir": "src",
   "assets_dir": "assets",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "usesBrands": false,
   "config": {
     "sources": "sources.json",

--- a/src/page_head/page_seo.pr
+++ b/src/page_head/page_seo.pr
@@ -38,6 +38,9 @@
         {[ description = description.extended(configuration.seoDescriptionPrefix, configuration.seoDescriptionSuffix) /]}
     {[/]}
 {[/]}
+{* Escaped title and description *}
+{[ let escapedTitle = escapeHtml(title) /]}
+{[ let escapedDescription = escapeHtml(description) /]}
 {* URL *}
 {[ let url = pageUrl(page, ds.documentationDomain()) /]}
 {* Favicon *}
@@ -75,21 +78,21 @@
 {[/]}
 {* All SEO tags *}
 <!-- Primary Meta Tags -->
-<title>{{ title }}</title>
+<title>{{ escapedTitle }}</title>
 {[ if (title.count() > 0) ]}
-<meta name="title" content="{{ title }}" />
+<meta name="title" content="{{ escapedTitle }}" />
 {[/]}
 {[ if (description.count() > 0) ]}
-<meta name="description" content="{{ description }}" />
+<meta name="description" content="{{ escapedDescription }}" />
 {[/]}
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ url }}" />
 {[ if (title.count() > 0) ]}
-<meta property="og:title" content="{{ title }}" />
+<meta property="og:title" content="{{ escapedTitle }}" />
 {[/]}
 {[ if (description.count() > 0) ]}
-<meta property="og:description" content="{{ description }}" />
+<meta property="og:description" content="{{ escapedDescription }}" />
 {[/]}
 {[ if siteImageUrl ]}
 <meta property="og:image" content="{{ siteImageUrl }}" />
@@ -98,10 +101,10 @@
 <meta property="twitter:card" content="summary" />
 <meta property="twitter:url" content="{{ url }}" />
 {[ if (title.count() > 0) ]}
-<meta property="twitter:title" content="{{ title }}" />
+<meta property="twitter:title" content="{{ escapedTitle }}" />
 {[/]}
-{[ if (title.count() > 0) ]}
-<meta property="twitter:description" content="{{ description }}" />
+{[ if (description.count() > 0) ]}
+<meta property="twitter:description" content="{{ escapedDescription }}" />
 {[/]}
 {[ if siteImageUrl ]}
 <meta property="twitter:image" content="{{ siteImageUrl }}" />


### PR DESCRIPTION
Escape image and description texts for SEO blocks.

Below you can see the same page
<img width="703" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/ee268b1f-e981-44fb-a4f4-62eb5c3498b5">
<img width="941" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/d082a341-0a0a-4e19-b3e4-c056f6fdda46">


- **Without fix**
<img width="1092" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/93fff113-59df-44ac-bd08-417f2f484254">


- **With fix**
<img width="1091" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/b6896157-8710-4d28-a738-829106a2f0eb">

**Preview:**
<img width="478" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/ff3efe0c-af9d-4d6f-a985-65ffbf1c2b10">


