### PR TITLE
PF-167: Show release notes versions even when there is no changelog

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -6,7 +6,7 @@
   "organization": "Supernova",
   "source_dir": "src",
   "assets_dir": "assets",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "usesBrands": false,
   "config": {
     "sources": "sources.json",

--- a/src/page_body/structure/blocks_custom/page_block_custom_release_notes.pr
+++ b/src/page_body/structure/blocks_custom/page_block_custom_release_notes.pr
@@ -6,21 +6,26 @@
         {[ let index = 0 /]}
         {[ for version in versions ]}
         {* Ignore draft version, only show stable versions *}
-            {[ if ((!version.isSharedDraft) && version.changeLog) ]}
+            {[ if (!version.isSharedDraft) ]}
                 {[ let entries = changelogToEntries(version.changeLog) /]}
+                {[ let hasSomeEntries = (entries.count() > 0 || version.description) /]}
                 <h3 class="rn-heading">
                     {{ version.version }}{[ if (version.name !== null && version.name !== "") ]} – {{ version.name }} {[/]}
                     {[ if (index === 0) ]}
                         <span class="rn-heading-tag">Latest</span>
                     {[/]}
                 </h3>
+                {[ if version.description ]}
+                  <p>{{ withHTMLNewlines(version.description) }}</p>
+                {[/]}
                 {[ if (entries.count() > 0) ]}
                     <ul>
                     {[ for entry in entries ]}
                         <li>{{ entry }}</li>
                     {[/]}
                     </ul>
-                {[ else ]}
+                {[/]}
+                {[ if !hasSomeEntries ]}
                     <p>No release notes for this version</p>
                 {[/]}
                 {[ index = (index + 1) /]}


### PR DESCRIPTION
In React FE application we are missing changelog field during version creation.

Show description in release notes

versions:
<img width="810" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/27c3c104-b331-4c4f-abdf-4ec56155edd4">

published documentation example:
<img width="1415" alt="image" src="https://github.com/Supernova-Studio/exporter-documentation/assets/9402858/85bea0ff-a343-4a1d-ac10-790c994fe0e2">
