### PR TITLE
RCT-2902: FE - Bug | One of the options contains "contract" instead of "contrast" copy

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -62,7 +62,7 @@
         "key": "lookAndFeelAccentSurfaceColor",
         "type": "color",
         "label": "Surface accent color",
-        "description": "Used for backgrounds of active and selected items. This color should meet AA+ contract criteria against the main accent color. Default color: #ecf4ff.",
+        "description": "Used for backgrounds of active and selected items. This color should meet AA+ contrast criteria against the main accent color. Default color: #ecf4ff.",
         "category": "Look & feel"
       },
       {


### PR DESCRIPTION
- fixed typo `contract` -> `contrast`