### PR TITLE
RCT-3789: Fix component overflow

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -6,7 +6,7 @@
   "organization": "Supernova",
   "source_dir": "src",
   "assets_dir": "assets",
-  "version": "4.16.2",
+  "version": "4.16.3",
   "usesBrands": false,
   "config": {
     "sources": "sources.json",

--- a/src/page_body/structure/blocks/page_block_figma_components.pr
+++ b/src/page_body/structure/blocks/page_block_figma_components.pr
@@ -23,7 +23,7 @@
 
                 {[ for componentPreview in componentPreviews ]}
                     <div class="figma-component">
-                        <div class="figma-component-image figma-component-image-border {{ showChecker ? "checkered-background-light" : ""}}" style="{{ block.figmaComponentsBlockConfig.previewContainerSize === "Centered" ? "height: 116px;" : "" }}background-color: {{ backgroundColor }};"">
+                        <div class="figma-component-image figma-component-image-border {{ showChecker ? "checkered-background-light" : ""}}" style="{{ block.figmaComponentsBlockConfig.previewContainerSize === "Centered" ? "height: 116px;" : "" }} background-color: {{ backgroundColor }};"">
                             <img src="{{ componentPreview.component.thumbnailUrl }}" alt="{{ componentPreview.name }}" height="{{ componentPreview.component.origin?.height }}" width="{{ componentPreview.component.origin?.width }}" />
                         </div>
                         {[ if (block.figmaComponentsBlockConfig.showComponentName || block.figmaComponentsBlockConfig.showPropertyList || block.figmaComponentsBlockConfig.showComponentDescription) ]}
@@ -105,6 +105,7 @@
                                         <div class="popover-body"></div>
                                     </div>
                                 '
+                                style="{{ block.figmaComponentsBlockConfig.previewContainerSize === "Centered" ? "height: 116px;" : "" }}"
                             >
                                 <img src="{{ componentPreview.component.thumbnailUrl }}" alt="{{ componentPreview.name }}" height="{{ componentPreview.component.origin?.height }}" width="{{ componentPreview.component.origin?.width }}" />
                             </div>


### PR DESCRIPTION
The height of the component has not been restricted when using centered, this caused an overflow

https://linear.app/supernova-io/issue/RCT-3789/ex-docs-bug-or-specific-tall-component-overflows-in-the-published-docs