### PR TITLE
Fix empty side navigation menu bug

### DIFF
--- a/src/page_body/structure/page_body_structure_content.pr
+++ b/src/page_body/structure/page_body_structure_content.pr
@@ -16,13 +16,19 @@
         {[ hasTopLevelHeading = true /]}
     {[/]}
 {[/]}
-{[ let showTOC = (hasHeading && configuration.tocShow) /]}
+{* Count displayable headings to ensure we don't show empty TOC *}
+{[ let displayableHeadingCount = 0 /]}
+{[ for block in page.blocks ]}
+    {[ if (block.type.equals("Heading") && ((!configuration.tocHideHeading3 && block.headingType <= 3) || (configuration.tocHideHeading3 && block.headingType <= 2))) ]}
+        {[ displayableHeadingCount = (displayableHeadingCount + 1) /]}
+    {[/]}
+{[/]}
+{[ let showTOC = (hasHeading && configuration.tocShow && displayableHeadingCount > 0) /]}
 {[ let showTOCOnHomepage = (!isHomepage || (isHomepage && configuration.tocShowOnHomepage)) /]}
 
 {*
      Check if we're on homepage and we want to show TOC in there — if yes, let's not even render TOC container 
      With one exception — if there is a sidebar, we need to render TOC container to make sure the page layout doesn't jump when navigating across pages
-     However, only show TOC content (header + links) when there are actually displayable headings
  *}
 {[ if (showTOCOnHomepage || pageConfiguration.showSidebar) ]}
     <div id="content-nav-container">

--- a/src/page_body/structure/page_body_structure_content.pr
+++ b/src/page_body/structure/page_body_structure_content.pr
@@ -20,10 +20,11 @@
 {[ let showTOCOnHomepage = (!isHomepage || (isHomepage && configuration.tocShowOnHomepage)) /]}
 
 {*
-     Only render TOC container when there's actual content to display.
-     This prevents empty "ON THIS PAGE" sections when only H4/H5 headings are present.
+     Check if we're on homepage and we want to show TOC in there — if yes, let's not even render TOC container 
+     With one exception — if there is a sidebar, we need to render TOC container to make sure the page layout doesn't jump when navigating across pages
+     However, only show TOC content (header + links) when there are actually displayable headings
  *}
-{[ if (showTOC && showTOCOnHomepage) ]}
+{[ if (showTOCOnHomepage || pageConfiguration.showSidebar) ]}
     <div id="content-nav-container">
         <nav id="content-nav">
         {[ if showTOC ]}

--- a/src/page_body/structure/page_body_structure_content.pr
+++ b/src/page_body/structure/page_body_structure_content.pr
@@ -20,10 +20,10 @@
 {[ let showTOCOnHomepage = (!isHomepage || (isHomepage && configuration.tocShowOnHomepage)) /]}
 
 {*
-     Check if we're on homepage and we want to show TOC in there — if yes, let's not even render TOC container 
-     With one exception — if there is a sidebar, we need to render TOC container to make sure the page layout doesn't jump when navigating across pages
+     Only render TOC container when there's actual content to display.
+     This prevents empty "ON THIS PAGE" sections when only H4/H5 headings are present.
  *}
-{[ if (showTOCOnHomepage || pageConfiguration.showSidebar) ]}
+{[ if (showTOC && showTOCOnHomepage) ]}
     <div id="content-nav-container">
         <nav id="content-nav">
         {[ if showTOC ]}


### PR DESCRIPTION
Prevent empty side navigation menu from displaying by only rendering the Table of Contents (TOC) container when there are actual headings to show.

Previously, the TOC container would render if `showTOCOnHomepage` was true or `pageConfiguration.showSidebar` was true, even if no H1, H2, or H3 headings were present. This resulted in an empty "ON THIS PAGE" section when a page only contained H4/H5 headings. The updated condition ensures the TOC container is only rendered when `showTOC` is true (meaning displayable headings exist) and `showTOCOnHomepage` is true, resolving the confusing empty state.

---
Linear Issue: [RCT-4877](https://linear.app/supernova-io/issue/RCT-4877/fe-bug-or-published-documentation-displays-empty-side-navigation-menu)

<a href="https://cursor.com/background-agent?bcId=bc-fa10f553-a498-4873-b245-421237ce7b7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fa10f553-a498-4873-b245-421237ce7b7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

